### PR TITLE
Modify samplePage css

### DIFF
--- a/src/components/organisms/CodeEditor.vue
+++ b/src/components/organisms/CodeEditor.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 				automaticLayout: true,
 				scrollBeyondLastLine: false,
 				scrollbar: {
-					alwaysConsumeMouseWheel: true
+					alwaysConsumeMouseWheel: false
 				},
 				minimap: {
 					enabled: false

--- a/src/components/pages/SamplePage.vue
+++ b/src/components/pages/SamplePage.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 	.container-editor {
 		width: 100%;
 		height: 100%;
-		overflow: scroll;
+		overflow: inherit;
 		display: flex;
 		flex-direction: row;
 		position: relative;
@@ -209,7 +209,7 @@ export default defineComponent({
 	.container-editor {
 		width: 100%;
 		height: 100%;
-		overflow: scroll;
+		overflow: inherit;
 		display: flex;
 		flex-direction: row;
 		position: relative;

--- a/src/components/pages/SamplePage.vue
+++ b/src/components/pages/SamplePage.vue
@@ -154,7 +154,7 @@ export default defineComponent({
 	.container-editor {
 		width: 100%;
 		height: 100%;
-		overflow: inherit;
+		overflow: visible;
 		display: flex;
 		flex-direction: row;
 		position: relative;
@@ -209,7 +209,7 @@ export default defineComponent({
 	.container-editor {
 		width: 100%;
 		height: 100%;
-		overflow: inherit;
+		overflow: visible;
 		display: flex;
 		flex-direction: row;
 		position: relative;

--- a/src/composables/useGameContext.ts
+++ b/src/composables/useGameContext.ts
@@ -34,7 +34,6 @@ export function useGameContext() {
 	};
 
 	function handleError(err: ErrorEvent) {
-		if (err.message === "ResizeObserver loop limit exceeded") return;
 		addConsole({
 			type: "error",
 			name: err.toString(),

--- a/src/composables/useGameContext.ts
+++ b/src/composables/useGameContext.ts
@@ -34,6 +34,7 @@ export function useGameContext() {
 	};
 
 	function handleError(err: ErrorEvent) {
+		if (err.message === "ResizeObserver loop limit exceeded") return;
 		addConsole({
 			type: "error",
 			name: err.toString(),


### PR DESCRIPTION
## 概要

サンプルページで画面領域が小さい場合(window幅 1000位)やコンテンツが大きすぎる場合( [アニメーション制御デモページ](https://akashic-games.github.io/demo/?title=animation-showcase))、下部のソースエディター領域がほぼ表示されなくるためスクロールでソースエディター領域全体が表示できるよう css を修正します。
