### PR TITLE
fix: support for receiving the game.json URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Akashic Playground
 
-[website](https://akashic-games.github.io/playground/#/edit/default)
+[Demo](https://akashic-games.github.io/playground/#/presets/default)
 
 # development
 

--- a/src/components/pages/IndexPage.vue
+++ b/src/components/pages/IndexPage.vue
@@ -2,13 +2,87 @@
 	<div>
 		<h2>Playground</h2>
 		<ul>
-			<li><router-link :to="{ name: 'edit', params: { name: 'default' } }">Playground (default)</router-link></li>
-			<li><router-link :to="{ name: 'edit', params: { name: 'timeline' } }">Playground (timeline)</router-link></li>
-			<li><router-link :to="{ name: 'edit', params: { name: 'label' } }">Playground (label)</router-link></li>
 			<li>
-				<router-link :to="{ name: 'edit', params: { name: 'box2d' }, query: { nodl: null } }"
-					>Playground (box2d, DLボタン非表示)</router-link
+				<router-link
+					:to="{
+						name: 'edit',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'helloworld',
+									uri: 'https://akashic-games.github.io/demo/content/helloworld/game.json'
+								})
+							)
+						}
+					}"
+					>Hello World</router-link
 				>
+			</li>
+			<li>
+				<router-link
+					:to="{
+						name: 'edit',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'oekaki',
+									uri: 'https://akashic-games.github.io/demo/content/oekaki/game.json'
+								})
+							)
+						}
+					}"
+					>おえかき</router-link
+				>
+			</li>
+			<li>
+				<router-link
+					:to="{
+						name: 'edit',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'newtons-cradle',
+									uri: 'https://akashic-games.github.io/demo/content/newtons-cradle/game.json'
+								})
+							)
+						},
+						query: { nodl: null }
+					}"
+					>ニュートンのゆりかご (DLボタン非表示)</router-link
+				>
+			</li>
+			<li>
+				<router-link
+					:to="{
+						name: 'edit',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'monban',
+									uri: 'https://akashic-games.github.io/demo/content/monban/game.json'
+								})
+							)
+						}
+					}"
+					>門番</router-link
+				>
+			</li>
+		</ul>
+		<h2>Playground (presets)</h2>
+		<ul>
+			<li>
+				<router-link :to="{ name: 'preset', params: { name: 'default' } }">default</router-link>
+			</li>
+			<li>
+				<router-link :to="{ name: 'preset', params: { name: 'timeline' } }">timeline</router-link>
+			</li>
+			<li><router-link :to="{ name: 'preset', params: { name: 'label' } }">label</router-link></li>
+			<li>
+				<router-link :to="{ name: 'preset', params: { name: 'box2d' }, query: { nodl: null } }">box2d (DLボタン非表示)</router-link>
 			</li>
 		</ul>
 		<h2>Sample</h2>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,24 @@ const router = createRouter({
 			component: () => import("~/components/pages/IndexPage.vue")
 		},
 		{
-			path: "/edit/:name/",
+			path: "/edit/:base64_uri_params",
 			name: "edit",
+			component: () => import("~/components/pages/PlaygroundPage.vue"),
+			props: router => {
+				const params: UriParameter = JSON.parse(decode(router.params.base64_uri_params.toString()));
+				if (params.type !== "gameJsonUri") {
+					throw new Error("Parse Error: unknown uri parameter");
+				}
+				return {
+					name: params.name ?? "noname",
+					gameJsonUri: params.uri,
+					showDownloadButton: router.query.nodl !== null // download ボタンを非表示化 (query の初期値は null)
+				};
+			}
+		},
+		{
+			path: "/presets/:name/",
+			name: "preset",
 			component: () => import("~/components/pages/PlaygroundPage.vue"),
 			props: router => {
 				const gameJsonUri = urlJoin(


### PR DESCRIPTION
# このPullRequestが解決する内容
デフォルトのページ (`/edit`) に外部から game.json の URL を与えることができなかったため、与えられるように修正します。
既存のプリセットを表示するパスについては `/presets/~~` へ移行します。