### PR TITLE
feat: add download route

### DIFF
--- a/src/components/atoms/BaseButton.vue
+++ b/src/components/atoms/BaseButton.vue
@@ -12,7 +12,7 @@ defineProps<Props>();
 
 <style lang="scss" scoped>
 button {
-	display: flex;
+	display: inline-flex;
 	justify-content: center;
 	align-items: center;
 	padding: 0.5em 1em;

--- a/src/components/pages/DownloadPage.vue
+++ b/src/components/pages/DownloadPage.vue
@@ -14,8 +14,7 @@
 </template>
 
 <script setup lang="ts">
-import { provide } from "vue";
-import { onMounted } from "vue";
+import { onMounted, provide } from "vue";
 import BaseButton from "~/components/atoms/BaseButton.vue";
 import { useGameContext, useGameContextKey } from "~/composables/useGameContext";
 import { useGameJSONResolver, useGameJSONResolverKey } from "~/composables/useGameJSONResolver";

--- a/src/components/pages/DownloadPage.vue
+++ b/src/components/pages/DownloadPage.vue
@@ -40,9 +40,6 @@ const download = async () => {
 	await downloadAsZip(props.name, gameConfs.pseudoFiles);
 };
 
-console.log("autoStartDownload", props.autoStartDownload);
-console.log("autoCloseWindow", props.autoCloseWindow);
-
 onMounted(async () => {
 	await gameConfs.fetchPseudoFilesFromUri(props.gameJsonUri);
 	if (props.autoStartDownload) {

--- a/src/components/pages/DownloadPage.vue
+++ b/src/components/pages/DownloadPage.vue
@@ -1,0 +1,75 @@
+<template>
+	<div>
+		<div class="message">
+			<p>Trying to download the game.</p>
+			<p>If the download doesn't start automatically, please click the following:</p>
+		</div>
+		<div class="button">
+			<p>
+				<BaseButton :on-click="download"> Download </BaseButton>
+			</p>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { provide } from "vue";
+import { onMounted } from "vue";
+import BaseButton from "~/components/atoms/BaseButton.vue";
+import { useGameContext, useGameContextKey } from "~/composables/useGameContext";
+import { useGameJSONResolver, useGameJSONResolverKey } from "~/composables/useGameJSONResolver";
+import { downloadAsZip } from "~/utils/downloadAsZip";
+
+interface Props {
+	gameJsonUri: string;
+	name: string;
+	autoStartDownload?: boolean;
+	autoCloseWindow?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	autoStartDownload: true,
+	autoCloseWindow: false
+});
+
+const gameConfs = useGameJSONResolver();
+provide(useGameJSONResolverKey, gameConfs);
+provide(useGameContextKey, useGameContext());
+
+const download = async () => {
+	await downloadAsZip(props.name, gameConfs.pseudoFiles);
+};
+
+console.log("autoStartDownload", props.autoStartDownload);
+console.log("autoCloseWindow", props.autoCloseWindow);
+
+onMounted(async () => {
+	await gameConfs.fetchPseudoFilesFromUri(props.gameJsonUri);
+	if (props.autoStartDownload) {
+		await download();
+
+		// NOTE: 自動ダウンロード時のみ対応
+		if (props.autoCloseWindow) {
+			window.close();
+		}
+	}
+});
+</script>
+
+<style lang="scss" scoped>
+div {
+	padding: 10px;
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	line-height: 1.8;
+
+	.button {
+		> p {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+		}
+	}
+}
+</style>

--- a/src/components/pages/DownloadPage.vue
+++ b/src/components/pages/DownloadPage.vue
@@ -2,7 +2,8 @@
 	<div>
 		<div class="message">
 			<p>Trying to download the game.</p>
-			<p>If the download doesn't start automatically, please click the following:</p>
+			<p v-if="autoStartDownload">If the download doesn't start automatically, please click the following:</p>
+			<p v-else>To start the download, please click the following:</p>
 		</div>
 		<div class="button">
 			<p>

--- a/src/components/pages/IndexPage.vue
+++ b/src/components/pages/IndexPage.vue
@@ -177,6 +177,70 @@
 				>
 			</li>
 		</ul>
+		<h2>Download</h2>
+		<ul>
+			<li>
+				<router-link
+					target="_blank"
+					:to="{
+						name: 'download',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'helloworld',
+									uri: 'https://akashic-games.github.io/demo/content/helloworld/game.json'
+								})
+							)
+						}
+					}"
+					>Hello World</router-link
+				>
+			</li>
+			<li>
+				<router-link
+					target="_blank"
+					:to="{
+						name: 'download',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'helloworld',
+									uri: 'https://akashic-games.github.io/demo/content/helloworld/game.json'
+								})
+							)
+						},
+						query: {
+							autoStart: null
+						}
+					}"
+					>Hello World (auto start)</router-link
+				>
+			</li>
+			<li>
+				<router-link
+					target="_blank"
+					:to="{
+						name: 'download',
+						params: {
+							base64_uri_params: encode(
+								JSON.stringify({
+									type: 'gameJsonUri',
+									name: 'helloworld',
+									uri: 'https://akashic-games.github.io/demo/content/helloworld/game.json'
+								})
+							)
+						},
+						query: {
+							autoStart: null,
+							autoClose: null
+						}
+					}"
+					>Hello World (auto start &amp; close window)</router-link
+				>
+			</li>
+		</ul>
 	</div>
 </template>
 

--- a/src/composables/__tests__/useGameJSONResolver.spec.ts
+++ b/src/composables/__tests__/useGameJSONResolver.spec.ts
@@ -65,6 +65,16 @@ describe("useGameJSONResolver", () => {
 						prop: "se"
 					}
 				},
+				bgm: {
+					type: "audio",
+					path: "audio/bgm",
+					duration: 25000,
+					systemId: "music",
+					hint: {
+						extensions: [".ogg", ".m4a", ".aac"],
+						prop: "bgm"
+					}
+				},
 				bin: {
 					type: "binary",
 					path: "bin/data.bin",
@@ -104,6 +114,8 @@ describe("useGameJSONResolver", () => {
 			imageFile,
 			// se
 			seFile,
+			// bgm
+			bgmFile,
 			// data.bin
 			binFile,
 			// unknown
@@ -157,9 +169,22 @@ describe("useGameJSONResolver", () => {
 		expect(se.duration).toBe(1000);
 		expect(se.filename).toBe("se");
 		expect(se.hint).toEqual({
+			extensions: [".ogg", ".aac"],
 			prop: "se"
 		});
 		expect(se.global).toBe(false);
+
+		const bgm = bgmFile as PseudoAudioAssetFile;
+		expect(bgm.assetType).toBe("audio");
+		expect(bgm.editorType).toBe("audio");
+		expect(bgm.systemId).toBe("music");
+		expect(bgm.duration).toBe(25000);
+		expect(bgm.filename).toBe("bgm");
+		expect(bgm.hint).toEqual({
+			extensions: [".ogg", ".m4a", ".aac"],
+			prop: "bgm"
+		});
+		expect(bgm.global).toBe(false);
 
 		const bin = binFile as PseudoBinaryAssetFile;
 		expect(bin.assetType).toBe("binary");

--- a/src/composables/useGameJSONResolver.ts
+++ b/src/composables/useGameJSONResolver.ts
@@ -183,6 +183,9 @@ export function useGameJSONResolver() {
 				global
 			};
 		} else if (asset.type === "audio") {
+			// FIXME: generateGameJSON() と処理が重複している。統一すべき。
+			const hint = asset.hint ? { ...asset.hint } : { extensions: undefined };
+			hint.extensions = hint.extensions ? hint.extensions : [".ogg", ".aac"]; // FIXME: この値についてはどこかで定数化しておくべきかもしれない
 			return {
 				id: assetId,
 				name: assetId,
@@ -192,7 +195,7 @@ export function useGameJSONResolver() {
 				path: asset.path,
 				filename,
 				duration: asset.duration || 0,
-				hint: asset.hint,
+				hint,
 				systemId: asset.systemId,
 				loop: !!asset.loop,
 				global

--- a/src/composables/useGameJSONResolver.ts
+++ b/src/composables/useGameJSONResolver.ts
@@ -185,7 +185,7 @@ export function useGameJSONResolver() {
 		} else if (asset.type === "audio") {
 			// FIXME: generateGameJSON() と処理が重複している。統一すべき。
 			const hint = asset.hint ? { ...asset.hint } : { extensions: undefined };
-			hint.extensions = hint.extensions ? hint.extensions : [".ogg", ".aac"]; // FIXME: この値についてはどこかで定数化しておくべきかもしれない
+			hint.extensions ??= [".ogg", ".aac"]; // FIXME: この値についてはどこかで定数化しておくべきかもしれない
 			return {
 				id: assetId,
 				name: assetId,
@@ -286,7 +286,7 @@ export function useGameJSONResolver() {
 				};
 			} else if (asset.assetType === "audio") {
 				const hint = asset.hint ? { ...asset.hint } : { extensions: undefined };
-				hint.extensions = hint.extensions ? hint.extensions : [".ogg", ".aac"]; // FIXME: この値についてはどこかで定数化しておくべきかもしれない
+				hint.extensions ??= [".ogg", ".aac"]; // FIXME: この値についてはどこかで定数化しておくべきかもしれない
 				gameJSON.assets[asset.id] = {
 					type: "audio",
 					path: asset.path,

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,6 +67,23 @@ const router = createRouter({
 					showTab
 				};
 			}
+		},
+		{
+			path: "/download/:base64_uri_params",
+			name: "download",
+			component: () => import("~/components/pages/DownloadPage.vue"),
+			props: router => {
+				const params: UriParameter = JSON.parse(decode(router.params.base64_uri_params.toString()));
+				if (params.type !== "gameJsonUri") {
+					throw new Error("Parse Error: unknown uri parameter");
+				}
+				return {
+					name: params.name ?? "noname",
+					gameJsonUri: params.uri,
+					autoStartDownload: router.query.autoStart === null, // 自動でダウンロードを開始する (query の初期値は null)
+					autoCloseWindow: router.query.autoClose === null // 自動でタブ or ウィンドウを閉じる (query の初期値は null)
+				};
+			}
 		}
 	]
 });


### PR DESCRIPTION
# このPullRequestが解決する内容
* コンテンツのダウンロードをサポートする `/download` のルートを追加します
* コンテンツダウンロード時のオーディオアセットの `hint.extensions` に考慮漏れがあったため修正します